### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP (Model Context Protocol) server that provides access to the Australian Bureau of Statistics (ABS) Data API. This server allows AI assistants to query and analyze ABS statistical data.
 
+<a href="https://glama.ai/mcp/servers/0b4h7ixci9"><img width="380" height="200" src="https://glama.ai/mcp/servers/0b4h7ixci9/badge" alt="Australian Bureau of Statistics (ABS) MCP server" /></a>
+
 ## Features
 
 - Query ABS datasets with optional filters


### PR DESCRIPTION
This PR adds a badge for the Australian Bureau of Statistics (ABS) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/0b4h7ixci9"><img width="380" height="200" src="https://glama.ai/mcp/servers/0b4h7ixci9/badge" alt="Australian Bureau of Statistics (ABS) MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.